### PR TITLE
Fix HTTP Documentation

### DIFF
--- a/src/modules/http/index.md
+++ b/src/modules/http/index.md
@@ -44,7 +44,7 @@ Cookies and session are independent modules which are not added to the Http modu
 
 ## Versions
 
-There are currently two versions of leaf http. Click on your version of choice to view it's docs.
+There are currently two versions of Leaf Http. Click on your version of choice to view its docs.
 
 - [v1](/modules/http/v/1/)
 - [v2](/modules/http/v/2/)

--- a/src/modules/http/index.md
+++ b/src/modules/http/index.md
@@ -24,13 +24,13 @@ The available classes in the Http module are:
 
 ## Installation
 
-You can install the http module with the [leaf cli](https://cli.leafphp.dev):
+You can install the http module with the [Leaf CLI](https://cli.leafphp.dev):
 
 ```sh
 leaf install http
 ```
 
-or with composer:
+or with Composer:
 
 ```sh
 composer require leafs/http
@@ -63,7 +63,7 @@ This interface allows you to manage headers in your application. [Read the docs]
 
 ## Cache
 
-This interface allows you to manage http cache in your app. [Read the docs](/modules/http/v/2/cache)
+This interface allows you to manage HTTP cache in your app. [Read the docs](/modules/http/v/2/cache)
 
 ## Session (module)
 


### PR DESCRIPTION
## Description of Problem

There are typos and casing problems in the [HTTP documentation](https://leafphp.dev/modules/http/).

## Proposed Solution

This PR;
- fixes a minor typo,
- fixes casing issues (HTTP instead of http, Leaf instead of leaf, Composer instead of composer).
