### PR TITLE
Fix: Updated cors installation command typo

### DIFF
--- a/src/modules/cors/index.md
+++ b/src/modules/cors/index.md
@@ -18,7 +18,7 @@ leaf install cors
 or
 
 ```sh
-composer reqiure leafs/cors
+composer require leafs/cors
 ```
 
 ## Usage


### PR DESCRIPTION
## Description of the Problem

There were a typo in the cors installation command

## Proposed Solution

Removed the typo error and changed `reqiure` to `require`