### PR TITLE
Fix code snippets

### DIFF
--- a/src/docs/routing/route-groups.md
+++ b/src/docs/routing/route-groups.md
@@ -53,7 +53,7 @@ app()->group('/admin', ['middleware' => 'auth', function () {
   app()->get('/users', function () {
     echo 'admin users';
   });
-});
+}]);
 ```
 
 Or you can directly pass the middleware in like this:
@@ -71,7 +71,7 @@ app()->group('/user', ['middleware' => $middleware, function () {
   app()->get('/(\d+)', function ($id) {
     response()->markup("user $id");
   });
-});
+}]);
 ```
 
 ## Subfolder Support


### PR DESCRIPTION
## Description of Problem
There is a couple of typos (missing closing square brackets) in the route group middleware code snippets.

## Proposed Solution
This PR fixes a couple those small typos for the route group middleware code snippets.

